### PR TITLE
Fix: category combo box + Add: remove transaction in daily summary

### DIFF
--- a/src/app/menu/page.tsx
+++ b/src/app/menu/page.tsx
@@ -1,6 +1,3 @@
-
-
-
 'use client'
 
 import { useState, useMemo } from 'react';
@@ -102,10 +99,29 @@ export default function MenuPage() {
     const [isAlertOpen, setIsAlertOpen] = useState(false);
     const [itemToDelete, setItemToDelete] = useState<MenuItem | null>(null);
     
-    const categories = useMemo(() => {
-        const uniqueCategories = new Set(menuItems.map(item => item.category).filter(Boolean));
-        return Array.from(uniqueCategories).map(cat => ({ value: cat!, label: cat! }));
+    const [allCategories, setAllCategories] = useState<{ value: string; label: string }[]>([]);
+
+    useMemo(() => {
+        const uniqueCategories = new Set(menuItems.map(item => item.category).filter(Boolean) as string[]);
+        setAllCategories(Array.from(uniqueCategories).map(cat => ({ value: cat, label: cat })));
     }, [menuItems]);
+
+    const handleCategoryChange = (value: string) => {
+        form.setValue('category', value, { shouldValidate: true });
+        
+        const isNew = !allCategories.some(cat => cat.value.toLowerCase() === value.toLowerCase());
+        
+        if (isNew && value) {
+            const newCategory = { value, label: value };
+            setAllCategories(prev => {
+                // Avoid adding duplicates if user types fast
+                if (prev.some(p => p.value.toLowerCase() === newCategory.value.toLowerCase())) {
+                    return prev;
+                }
+                return [...prev, newCategory];
+            });
+        }
+    };
 
     const form = useForm<MenuItemFormValues>({
         resolver: zodResolver(menuItemSchema),
@@ -298,9 +314,9 @@ export default function MenuPage() {
                                             <FormLabel>Category</FormLabel>
                                             <FormControl>
                                                <Combobox
-                                                    options={categories}
+                                                    options={allCategories}
                                                     value={field.value ?? ''}
-                                                    onChange={field.onChange}
+                                                    onChange={handleCategoryChange}
                                                     placeholder="Select or create a category..."
                                                 />
                                             </FormControl>

--- a/src/components/layout/AppProvider.tsx
+++ b/src/components/layout/AppProvider.tsx
@@ -57,6 +57,7 @@ type AppContextType = {
   completedOrders: CompletedOrder[];
   allCompletedOrders: CompletedOrder[];
   lastCompletedOrder: CompletedOrder | null;
+  removeCompletedOrder: (orderId: string) => Promise<void>;
 
   storeStatus: StoreStatus | null;
 
@@ -483,6 +484,17 @@ export function AppProvider({ children }: { children: React.ReactNode }) {
     }
   }
 
+  const removeCompletedOrder = async (orderId: string) => {
+    const { error } = await supabase.from('completed_orders').delete().eq('id', orderId);
+    if (error) {
+        toast({ variant: 'destructive', title: 'Error deleting order', description: error.message });
+    } else {
+        setCompletedOrders(prev => prev.filter(o => o.id !== orderId));
+        setAllCompletedOrders(prev => prev.filter(o => o.id !== orderId));
+        toast({ title: 'Order deleted', description: 'The transaction has been removed.' });
+    }
+  };
+
   const saveAsOpenBill = async () => {
     if (!shop) return;
     const billPayload: Omit<OpenBill, 'id' | 'created_at'> = {
@@ -709,6 +721,7 @@ export function AppProvider({ children }: { children: React.ReactNode }) {
     completedOrders,
     allCompletedOrders,
     lastCompletedOrder,
+    removeCompletedOrder,
     storeStatus,
     setOrderItems,
     setFees,
@@ -736,7 +749,7 @@ export function AppProvider({ children }: { children: React.ReactNode }) {
     total,
     uploadImage,
     removeImage,
-  }), [isLoading, shop, shopMembers, isShopOwner, currency, taxRate, receiptSettings, menuItems, members, orderItems, fees, customer_name, member_id, orderStatus, openBills, editingBillId, completedOrders, allCompletedOrders, lastCompletedOrder, storeStatus, subtotal, total_fees, tax, total, activeOrderExists, unsavedOrder, user, authLoading, fetchData, updateStoreSettings, addMenuItem, updateMenuItem, removeMenuItem, addMember, getMemberById, getMemberByLookup, addItemToOrder, updateItemQuantity, removeItemFromOrder, addFeeToOrder, resetOrder, saveAsOpenBill, loadOrderFromBill, removeOpenBill, setEditingBillId, setUnsavedOrder, addOrderToHistory, endDay, startNewDay, uploadImage, removeImage, inviteMember, removeShopMember, updateMember, removeCustomerMember]);
+  }), [isLoading, shop, shopMembers, isShopOwner, currency, taxRate, receiptSettings, menuItems, members, orderItems, fees, customer_name, member_id, orderStatus, openBills, editingBillId, completedOrders, allCompletedOrders, lastCompletedOrder, storeStatus, subtotal, total_fees, tax, total, activeOrderExists, unsavedOrder, user, authLoading, fetchData, updateStoreSettings, addMenuItem, updateMenuItem, removeMenuItem, addMember, getMemberById, getMemberByLookup, addItemToOrder, updateItemQuantity, removeItemFromOrder, addFeeToOrder, resetOrder, saveAsOpenBill, loadOrderFromBill, removeOpenBill, setEditingBillId, setUnsavedOrder, addOrderToHistory, endDay, startNewDay, uploadImage, removeImage, inviteMember, removeShopMember, updateMember, removeCustomerMember, removeCompletedOrder]);
 
   return (
     <AppContext.Provider value={value}>

--- a/src/components/ui/combobox.tsx
+++ b/src/components/ui/combobox.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import * as React from "react"
-import { Check, ChevronsUpDown } from "lucide-react"
+import { Check, ChevronsUpDown, PlusCircle } from "lucide-react"
 
 import { cn } from "@/lib/utils"
 import { Button } from "@/components/ui/button"
@@ -39,6 +39,22 @@ export function Combobox({
   className
 }: ComboboxProps) {
   const [open, setOpen] = React.useState(false)
+  const [inputValue, setInputValue] = React.useState("")
+
+  const handleSelect = (currentValue: string) => {
+    const newValue = currentValue === value ? "" : currentValue
+    onChange(newValue)
+    setInputValue("")
+    setOpen(false)
+  }
+
+  const filteredOptions = options.filter(option => 
+    option.label.toLowerCase().includes(inputValue.toLowerCase())
+  );
+
+  const showCreateOption = inputValue && !filteredOptions.some(
+    option => option.label.toLowerCase() === inputValue.toLowerCase()
+  );
 
   return (
     <Popover open={open} onOpenChange={setOpen}>
@@ -56,23 +72,22 @@ export function Combobox({
         </Button>
       </PopoverTrigger>
       <PopoverContent className="w-[--radix-popover-trigger-width] p-0">
-        <Command
-          filter={(searchValue, itemValue) => {
-            return itemValue.toLowerCase().includes(searchValue.toLowerCase())
-          }}
-        >
-          <CommandInput placeholder={searchPlaceholder} />
+        <Command>
+          <CommandInput 
+            placeholder={searchPlaceholder}
+            value={inputValue}
+            onValueChange={setInputValue}
+          />
           <CommandList>
-            <CommandEmpty>{emptyMessage}</CommandEmpty>
+            <CommandEmpty>
+                {!showCreateOption && emptyMessage}
+            </CommandEmpty>
             <CommandGroup>
-              {options.map((option) => (
+              {filteredOptions.map((option) => (
                 <CommandItem
                   key={option.value}
-                  value={option.value}
-                  onSelect={(currentValue) => {
-                    onChange(currentValue === value ? "" : currentValue)
-                    setOpen(false)
-                  }}
+                  value={option.label}
+                  onSelect={handleSelect}
                 >
                   <Check
                     className={cn(
@@ -83,6 +98,16 @@ export function Combobox({
                   {option.label}
                 </CommandItem>
               ))}
+               {showCreateOption && (
+                <CommandItem
+                  value={inputValue}
+                  onSelect={() => handleSelect(inputValue)}
+                  className="flex items-center"
+                >
+                  <PlusCircle className="mr-2 h-4 w-4" />
+                  Create "{inputValue}"
+                </CommandItem>
+              )}
             </CommandGroup>
           </CommandList>
         </Command>


### PR DESCRIPTION
### Changes Made
1. Fixed category combo box bug (now supports proper category selection instead of only showing last added category).
2. Added "Remove Transaction" button in Daily Summary page:
   - Allows removing faulty transactions before “End Day”
   - Ensures only same-day edits are possible
   - Safer than retroactive edits in Supabase

### Notes
- Once "End Day" is done, transactions are locked (no edits possible via UI).
- This improves cashier workflow and reduces errors